### PR TITLE
Datetime filter bug

### DIFF
--- a/src/Components/FilterComponents/DateTime.js
+++ b/src/Components/FilterComponents/DateTime.js
@@ -17,14 +17,14 @@ function DateTime({
       // Convert it into GMT considering offset
       const offset = date.getTimezoneOffset()
       const localDateTime = new Date(date.getTime() - offset * 60 * 1000)
-      const timeString = localDateTime.toISOString()
+      const ISODateTime = localDateTime.toISOString()
 
       if (type === 'type1') {
         setStartDate(date)
         setInputStates((prevState) => {
           const newdata = prevState.slice()
           newdata[index]['logicValue'][0] = '_gte'
-          newdata[index]['inputValue'][0] = timeString
+          newdata[index]['inputValue'][0] = ISODateTime
           return newdata
         })
       } else {
@@ -32,7 +32,7 @@ function DateTime({
         setInputStates((prevState) => {
           const newdata = prevState.slice()
           newdata[index]['logicValue'][1] = '_lt'
-          newdata[index]['inputValue'][1] = timeString
+          newdata[index]['inputValue'][1] = ISODateTime
           return newdata
         })
       }

--- a/src/Components/FilterComponents/DateTime.js
+++ b/src/Components/FilterComponents/DateTime.js
@@ -8,8 +8,8 @@ function DateTime({
   fields,
   setCopyDisabled,
 }) {
-  const [startDate1, setStartDate1] = useState()
-  const [startDate2, setStartDate2] = useState()
+  const [startDate, setStartDate] = useState()
+  const [endDate, setEndDate] = useState()
 
   const handleDate = function (columnName, date, type) {
     setCopyDisabled(true)
@@ -33,7 +33,7 @@ function DateTime({
       }
 
       if (type === 'type1') {
-        setStartDate1(date)
+        setStartDate(date)
         setInputStates((prevState) => {
           const newdata = prevState.slice()
           newdata[index]['logicValue'][0] = '_gte'
@@ -41,7 +41,7 @@ function DateTime({
           return newdata
         })
       } else {
-        setStartDate2(date)
+        setEndDate(date)
         setInputStates((prevState) => {
           const newdata = prevState.slice()
           newdata[index]['logicValue'][1] = '_lt'
@@ -51,7 +51,7 @@ function DateTime({
       }
     } else {
       if (type === 'type1') {
-        setStartDate1(date)
+        setStartDate(date)
         setInputStates((prevState) => {
           const newdata = prevState.slice()
           console.log(newdata)
@@ -62,7 +62,7 @@ function DateTime({
           return newdata
         })
       } else {
-        setStartDate2(date)
+        setEndDate(date)
         setInputStates((prevState) => {
           const newdata = prevState.slice()
           if (newdata[index].logicValue.length === 1) {
@@ -81,7 +81,7 @@ function DateTime({
   return (
     <>
       <DatePicker
-        value={startDate1}
+        value={startDate}
         onChange={(date) => handleDate(columnName, date, 'type1')}
         format="yyyy-MM-dd"
         clearIcon="X"
@@ -92,7 +92,7 @@ function DateTime({
       />
       <i className="fa fa-long-arrow-right" aria-hidden="true"></i>
       <DatePicker
-        value={startDate2}
+        value={endDate}
         onChange={(date) => handleDate(columnName, date, 'type2')}
         format="yyyy-MM-dd"
         clearIcon="X"

--- a/src/Components/FilterComponents/DateTime.js
+++ b/src/Components/FilterComponents/DateTime.js
@@ -14,23 +14,10 @@ function DateTime({
   const handleDate = function (columnName, date, type) {
     setCopyDisabled(true)
     if (date) {
-      const dDate = date.toISOString().slice(0, 10)
-      const hour = date.getHours()
-      const minute = date.getMinutes().toString()
-      let timeString = null
-
-      const examples = fields.filter((val) => val.name === columnName)[0][
-        'example'
-      ]
-      const isISO = examples.includes('Z')
-
-      if (isISO) {
-        timeString = `${dDate} ${hour}:${minute}${
-          minute.length > 1 ? 'Z' : '0Z'
-        }`
-      } else {
-        timeString = `${dDate} ${hour}:${minute}`
-      }
+      // Convert it into GMT considering offset
+      const offset = date.getTimezoneOffset()
+      const localDateTime = new Date(date.getTime() - offset * 60 * 1000)
+      const timeString = localDateTime.toISOString()
 
       if (type === 'type1') {
         setStartDate(date)


### PR DESCRIPTION
In the current version of the app, the dates are set depending on user's local time, e.g., if I'm in GMT+X, the date is set to GMT-X when converted to ISO. Due to that bug, returned results from the Data API includes data for previous day.

Reproduce:

1. Go to the app and open the network tab in the developer tools.
2. Select datetime filter, e.g., April 1 2021.
3. Check the body of the query in the network tab. You can see that the date was converted to March 31 2021.

This PR includes:

* an approach from previous data explorer app where we're converting datetime values into ISO considering user's local timezone offset so if
* better (more explicit) variable names